### PR TITLE
test: deepen learner and offline e2e coverage

### DIFF
--- a/AGENT-HANDOFF.md
+++ b/AGENT-HANDOFF.md
@@ -1,11 +1,11 @@
 # Agent Handoff
 
-Last updated: 2026-03-26 after PR #54 merge
+Last updated: 2026-03-26 during MIP-037 branch work
 
 ## Current project state
 
-- `main` includes the merged offline batch from PR `#51`, the merged parent summary batch from PR `#53`, and the merged QA hardening batch from PR `#54`.
-- `progress.txt` contains the detailed session-by-session build log from the docs-only start through the MIP-035 QA hardening batch.
+- `main` includes the merged offline batch from PR `#51`, the merged parent summary batch from PR `#53`, the merged QA hardening batch from PR `#54`, and the merged critical learner-flow E2E batch from PR `#55`.
+- `progress.txt` contains the detailed session-by-session build log from the docs-only start through the MIP-037 broader E2E batch on the current branch.
 - The current implementation now covers:
   - app shell and Cloudflare Pages baseline
   - content and state validation
@@ -16,6 +16,7 @@ Last updated: 2026-03-26 after PR #54 merge
   - PWA installability, app-shell caching, content-pack caching, and safe refresh behavior
   - parent summary UI derived from local learner state only
   - stronger direct unit and component coverage for evaluation, progression, persistence, and learner mechanics
+  - critical learner, parent-summary, and offline-update Playwright coverage
 
 ## Best entry points in the codebase
 
@@ -38,31 +39,30 @@ Last updated: 2026-03-26 after PR #54 merge
 - `#51` offline and update flow batch
 - `#53` parent summary batch
 - `#54` QA hardening batch
+- `#55` critical learner-flow E2E batch
 
 ## Recommended next batch
 
-Most natural next step: critical-path end-to-end coverage.
+Most natural next step: deployed verification and production-like smoke coverage.
 
 Suggested next issues to create or execute:
 
-- `MIP-036` Add end-to-end coverage for critical learner flows
-- after that: `MIP-037` deployed Cloudflare Pages verification and production-like smoke coverage
+- `MIP-037` Deployed Cloudflare Pages verification and production-like smoke coverage
+- after that: fix any deployment-only regressions or deepen offline-return coverage if the deployed checks surface gaps
 
-## If continuing with MIP-036
+## If continuing with deployed verification
 
 Focus areas:
 
-- expand `tests/e2e/` beyond the existing smoke test
-- cover profile creation through the parent route
-- cover starting a lesson from the learner route
-- cover completing the first lesson and reaching the wrap-up route
-- cover resume behavior after a refresh or reload
-- add offline-start or offline-return assertions only if they stay practical and stable in Playwright
+- verify the actual deployed Pages environment still boots and routes correctly
+- smoke-test learner, parent, and offline-update surfaces against the deployed build
+- compare deployed behavior against local preview behavior, especially for PWA/update prompts and nested learner routes
+- keep fixes small and targeted if a deployment-only mismatch appears
 
 Likely files to touch:
 
 - `tests/e2e/`
-- possibly tiny testability tweaks in `src/routes/learn.tsx`, `src/routes/learn.map.tsx`, `src/routes/learn.completed.tsx`, and `src/routes/parents.tsx`
+- deployment config and Pages preview settings if needed
 - keep business rules in the existing `src/lib/*` modules rather than re-implementing them in tests or routes
 
 ## Operational conventions used in this repo
@@ -77,16 +77,16 @@ Likely files to touch:
 
 ## Current branch note
 
-PR `#54` is already merged. Start from updated `main` for the next batch.
+PR `#55` is already merged. Start from updated `main` for the next batch.
 
 ## Recommended first prompt for the next agent
 
 Read `AGENT-HANDOFF.md` and `progress.txt`, then continue from updated `main`.
 
-Start with `MIP-036`.
+Start with deployed verification work.
 Follow the repo workflow:
 - one new branch from `main`
 - one main commit per issue
 - append `progress.txt` before opening a PR
 
-Focus first on stable end-to-end coverage for profile creation, lesson start, lesson completion, and resume behavior. Add offline-return assertions only where the Playwright flow stays reliable, then run `pnpm lint` and `pnpm test` before opening the PR.
+Focus first on production-like Cloudflare Pages verification and deployed smoke checks. Reuse the broader local Playwright coverage as the baseline, then run `pnpm lint` and `pnpm test` before opening the PR.

--- a/progress.txt
+++ b/progress.txt
@@ -311,3 +311,32 @@ Learnings from the batch
 Current state
 - Critical learner flows now have direct Playwright coverage on top of the existing smoke test.
 - The next likely step is broader E2E depth around map progression, parent summary verification, and practical offline-return behavior.
+
+2026-03-26 Broader learner, parent, and offline E2E batch
+
+Completed work
+- MIP-037 expanded Playwright coverage across learner progression, parent summary verification, and practical offline or update prompts.
+
+What was added
+- Added broader learner-flow coverage that verifies completed-route navigation, world-map state, and next-step progression after replaying the first lesson enough to unlock the second lesson.
+- Added parent-summary coverage that verifies completed lessons, total stars, recent activity, rewards, and personalization remain visible after learner progress updates.
+- Added practical offline and update coverage by exposing stable test overrides for the service-worker prompt and content-pack update status, then verifying dismiss, safe refresh, and resumable progress recovery.
+
+Important file landmarks
+- tests/e2e/learner-flow.spec.ts now covers map progression, completed-route navigation, parent summary verification, and safe refresh recovery.
+- src/components/ReloadPrompt.tsx and src/components/ContentPackStatus.tsx now support stable test-time prompt and update-state overrides without changing production behavior.
+- src/routes/learn.map.tsx and src/routes/parents.tsx expose stable test identifiers for progression and parent-summary assertions.
+- src/lib/child-experience.ts and src/lib/models/app-models.ts now surface enough learner-state detail to recommend resumable, explicitly recommended, or unlocked next lessons correctly.
+
+Useful commands
+- pnpm lint
+- pnpm test:e2e
+- pnpm test
+
+Learnings from the batch
+- Practical offline Playwright coverage was much more reliable with narrow UI-state overrides than with brittle attempts to fully simulate service-worker lifecycle changes.
+- The recommendation and progression surfaces needed small read-model improvements before the end-to-end tests could verify realistic learner advancement states.
+
+Current state
+- Learner, parent-summary, and offline-update critical paths now have meaningful end-to-end coverage instead of only smoke coverage.
+- The next likely batch is Cloudflare Pages production-like verification plus any follow-up fixes surfaced by deployed smoke checks.

--- a/src/components/ContentPackStatus.tsx
+++ b/src/components/ContentPackStatus.tsx
@@ -24,6 +24,18 @@ export function ContentPackStatus({
     let active = true
 
     async function boot() {
+      const testOverride =
+        typeof window === 'undefined'
+          ? undefined
+          : window.__MATHINIK_TEST_CONTENT_STATUS__
+
+      if (testOverride?.status) {
+        setCachedVersion(testOverride.cachedVersion ?? null)
+        setLatestVersion(testOverride.latestVersion ?? currentVersion)
+        setStatus(testOverride.status)
+        return
+      }
+
       try {
         await cacheBundledContentPack()
         const nextStatus = await getContentUpdateStatus(currentVersion)

--- a/src/components/ReloadPrompt.tsx
+++ b/src/components/ReloadPrompt.tsx
@@ -1,4 +1,5 @@
 import { useRegisterSW } from 'virtual:pwa-register/react'
+import { useState } from 'react'
 import { buttonVariants } from '~/components/ui/button'
 
 export function ReloadPrompt() {
@@ -10,7 +11,25 @@ export function ReloadPrompt() {
     immediate: true,
   })
 
-  if (!offlineReady && !needRefresh) {
+  const [dismissed, setDismissed] = useState(false)
+  const promptOverride =
+    typeof window === 'undefined'
+      ? undefined
+      : window.__MATHINIK_TEST_SW_PROMPT__
+  const effectiveOfflineReady = promptOverride?.offlineReady ?? offlineReady
+  const effectiveNeedRefresh = promptOverride?.needRefresh ?? needRefresh
+  const promptSignature = `${effectiveOfflineReady ? '1' : '0'}:${effectiveNeedRefresh ? '1' : '0'}`
+  const [lastPromptSignature, setLastPromptSignature] =
+    useState(promptSignature)
+
+  if (lastPromptSignature !== promptSignature) {
+    setLastPromptSignature(promptSignature)
+    if (dismissed) {
+      setDismissed(false)
+    }
+  }
+
+  if ((!effectiveOfflineReady && !effectiveNeedRefresh) || dismissed) {
     return null
   }
 
@@ -18,12 +37,12 @@ export function ReloadPrompt() {
     <div className="fixed bottom-4 left-1/2 z-40 w-[min(92vw,32rem)] -translate-x-1/2 rounded-[1.75rem] border border-border/70 bg-background/95 p-4 shadow-2xl shadow-foreground/10 backdrop-blur-xl">
       <div className="space-y-3">
         <p className="text-sm font-semibold text-foreground">
-          {offlineReady
+          {effectiveOfflineReady
             ? 'Mathinik is ready to work offline.'
             : 'A fresh app version is available.'}
         </p>
         <div className="flex flex-wrap gap-3">
-          {needRefresh ? (
+          {effectiveNeedRefresh ? (
             <button
               className={buttonVariants({ size: 'lg' })}
               onClick={() => updateServiceWorker(true)}
@@ -35,6 +54,7 @@ export function ReloadPrompt() {
           <button
             className={buttonVariants({ size: 'lg', variant: 'secondary' })}
             onClick={() => {
+              setDismissed(true)
               setOfflineReady(false)
               setNeedRefresh(false)
             }}

--- a/src/lib/child-experience.test.ts
+++ b/src/lib/child-experience.test.ts
@@ -26,7 +26,55 @@ describe('child experience helpers', () => {
     ).activeProfile
 
     expect(getNextRecommendedLesson(activeProfile, lessons)?.id).toBe(
-      'g1-add-within-5-lesson-1'
+      'g1-add-within-5-lesson-2'
     )
+  })
+
+  it('falls back to the first lesson when no resume or recommendation exists', () => {
+    const lessons = normalizeContentPack(loadBundledContentPack()).lessons
+    const activeProfile = normalizeStateStore(
+      loadExampleStateStore()
+    ).activeProfile
+
+    if (!activeProfile) {
+      throw new Error('Expected active profile')
+    }
+
+    expect(
+      getNextRecommendedLesson(
+        {
+          ...activeProfile,
+          resumableLessonId: null,
+          recommendedLessonId: null,
+          unlockedLessonIds: [],
+          completedLessonIds: [],
+        },
+        lessons
+      )?.id
+    ).toBe('g1-add-within-5-lesson-1')
+  })
+
+  it('prefers an unlocked unfinished lesson when no explicit recommendation exists', () => {
+    const lessons = normalizeContentPack(loadBundledContentPack()).lessons
+    const activeProfile = normalizeStateStore(
+      loadExampleStateStore()
+    ).activeProfile
+
+    if (!activeProfile) {
+      throw new Error('Expected active profile')
+    }
+
+    expect(
+      getNextRecommendedLesson(
+        {
+          ...activeProfile,
+          resumableLessonId: null,
+          recommendedLessonId: null,
+          completedLessonIds: ['g1-add-within-5-lesson-1'],
+          unlockedLessonIds: ['g1-add-within-5-lesson-2'],
+        },
+        lessons
+      )?.id
+    ).toBe('g1-add-within-5-lesson-2')
   })
 })

--- a/src/lib/child-experience.ts
+++ b/src/lib/child-experience.ts
@@ -21,16 +21,35 @@ export function getNextRecommendedLesson(
     return lessons[0] ?? null
   }
 
-  const unlockedLessons = lessons.filter((lesson) =>
-    profile.recommendedLessonId
-      ? lesson.id === profile.recommendedLessonId || true
-      : true
-  )
+  if (profile.resumableLessonId) {
+    const resumableLesson = lessons.find(
+      (lesson) => lesson.id === profile.resumableLessonId
+    )
 
-  const unfinishedUnlockedLesson = unlockedLessons.find(
+    if (resumableLesson) {
+      return resumableLesson
+    }
+  }
+
+  if (profile.recommendedLessonId) {
+    const recommendedLesson = lessons.find(
+      (lesson) => lesson.id === profile.recommendedLessonId
+    )
+
+    if (recommendedLesson) {
+      return recommendedLesson
+    }
+  }
+
+  const nextUnlockedLesson = lessons.find(
     (lesson) =>
-      !profile.resumableLessonId || lesson.id !== profile.resumableLessonId
+      profile.unlockedLessonIds.includes(lesson.id) &&
+      !profile.completedLessonIds.includes(lesson.id)
   )
 
-  return unfinishedUnlockedLesson ?? lessons[0] ?? null
+  if (nextUnlockedLesson) {
+    return nextUnlockedLesson
+  }
+
+  return lessons[0] ?? null
 }

--- a/src/lib/models/app-models.ts
+++ b/src/lib/models/app-models.ts
@@ -36,6 +36,8 @@ export type ProfileModel = {
   displayName: string
   gradeStart: number
   avatarLabel: string
+  unlockedLessonIds: string[]
+  completedLessonIds: string[]
   unlockedLessonCount: number
   completedLessonCount: number
   totalStars: number
@@ -126,6 +128,8 @@ export function normalizeStateStore(state: StateStore): NormalizedStateModels {
     displayName: profile.displayName,
     gradeStart: profile.gradeStart,
     avatarLabel: profile.avatar?.mascotStyle ?? 'default mascot',
+    unlockedLessonIds: profile.progress.unlockedLessonIds,
+    completedLessonIds: profile.progress.completedLessonIds,
     unlockedLessonCount: profile.progress.unlockedLessonIds.length,
     completedLessonCount: profile.progress.completedLessonIds.length,
     totalStars: profile.progress.rewards.totalStars,

--- a/src/routes/learn.map.tsx
+++ b/src/routes/learn.map.tsx
@@ -64,6 +64,8 @@ function LearnMapRoute() {
                         ? 'rounded-[1.75rem] border border-primary/30 bg-primary/10 p-5'
                         : 'rounded-[1.75rem] border border-secondary/30 bg-secondary/10 p-5'
                   }
+                  data-state={item.state}
+                  data-testid={`map-item-${item.id}`}
                   key={item.id}
                 >
                   <p className="text-xs font-black uppercase tracking-[0.18em] text-primary">

--- a/src/routes/parents.tsx
+++ b/src/routes/parents.tsx
@@ -580,29 +580,35 @@ function ParentsRoute() {
 
             <div className="grid gap-3 md:grid-cols-3">
               <div className="rounded-[1.5rem] border border-border/60 bg-background/70 p-4">
-                <p className="text-xs font-black uppercase tracking-[0.18em] text-primary">
-                  Completed lessons
-                </p>
-                <p className="mt-2 text-2xl font-black tracking-tight text-foreground">
-                  {parentSummary?.completedLessons.length ?? 0}
-                </p>
+                <div data-testid="parent-summary-completed">
+                  <p className="text-xs font-black uppercase tracking-[0.18em] text-primary">
+                    Completed lessons
+                  </p>
+                  <p className="mt-2 text-2xl font-black tracking-tight text-foreground">
+                    {parentSummary?.completedLessons.length ?? 0}
+                  </p>
+                </div>
               </div>
               <div className="rounded-[1.5rem] border border-border/60 bg-background/70 p-4">
-                <p className="text-xs font-black uppercase tracking-[0.18em] text-primary">
-                  Total stars
-                </p>
-                <p className="mt-2 text-2xl font-black tracking-tight text-foreground">
-                  {parentSummary?.rewards.totalStars ?? 0}
-                </p>
+                <div data-testid="parent-summary-stars">
+                  <p className="text-xs font-black uppercase tracking-[0.18em] text-primary">
+                    Total stars
+                  </p>
+                  <p className="mt-2 text-2xl font-black tracking-tight text-foreground">
+                    {parentSummary?.rewards.totalStars ?? 0}
+                  </p>
+                </div>
               </div>
               <div className="rounded-[1.5rem] border border-border/60 bg-background/70 p-4">
-                <p className="text-xs font-black uppercase tracking-[0.18em] text-primary">
-                  Recent activity
-                </p>
-                <p className="mt-2 text-sm font-semibold text-foreground">
-                  {parentSummary?.recentActivity.lessonTitle ??
-                    'No recent activity yet'}
-                </p>
+                <div data-testid="parent-summary-recent">
+                  <p className="text-xs font-black uppercase tracking-[0.18em] text-primary">
+                    Recent activity
+                  </p>
+                  <p className="mt-2 text-sm font-semibold text-foreground">
+                    {parentSummary?.recentActivity.lessonTitle ??
+                      'No recent activity yet'}
+                  </p>
+                </div>
               </div>
             </div>
 

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,2 +1,14 @@
 /// <reference types="vite/client" />
 /// <reference types="vite-plugin-pwa/client" />
+
+interface Window {
+  __MATHINIK_TEST_SW_PROMPT__?: {
+    offlineReady?: boolean
+    needRefresh?: boolean
+  }
+  __MATHINIK_TEST_CONTENT_STATUS__?: {
+    status?: 'checking' | 'ready' | 'offline' | 'update-available'
+    cachedVersion?: string | null
+    latestVersion?: string
+  }
+}

--- a/tests/e2e/learner-flow.spec.ts
+++ b/tests/e2e/learner-flow.spec.ts
@@ -47,6 +47,112 @@ test('parent setup can create a profile and complete the first lesson flow', asy
   await expect(page.getByText('Total stars: 3')).toBeVisible()
 })
 
+test('lesson completion updates map progression and parent summary surfaces', async ({
+  page,
+}) => {
+  await createProfile(page, 'Luna')
+
+  await page.goto('/parents')
+  await page.getByRole('button', { name: 'owl guide' }).click()
+  await expect(page.getByText('Current style: owl-guide')).toBeVisible()
+
+  await completeFirstLesson(page)
+
+  await page.getByRole('link', { name: 'Back to child home' }).click()
+  await page.waitForURL('**/learn')
+  await expect(
+    page.getByText('Next recommended lesson: Build Groups and Equations')
+  ).toBeVisible()
+
+  await completeFirstLesson(page)
+
+  await page.getByRole('link', { name: 'Back to child home' }).click()
+  await page.waitForURL('**/learn')
+  await expect(
+    page.getByText('Next recommended lesson: Show and Check Sums Within 5')
+  ).toBeVisible()
+
+  await page.goto('/learn/completed')
+  await page.getByRole('link', { name: 'View next lesson' }).click()
+  await page.waitForURL('**/learn/map')
+
+  await expect(
+    page.getByRole('heading', { name: 'World map progression' })
+  ).toBeVisible()
+  await expect(
+    page.getByTestId('map-item-g1-add-within-5-lesson-1')
+  ).toContainText('Grade 1 - completed')
+  await expect(
+    page.getByTestId('map-item-g1-add-within-5-lesson-2')
+  ).toContainText('Grade 1 - next')
+
+  await page.getByRole('link', { name: 'Back to child home' }).click()
+  await page.waitForURL('**/learn')
+
+  await page.goto('/parents')
+  await expect(page.getByTestId('parent-summary-completed')).toContainText('1')
+  await expect(page.getByTestId('parent-summary-stars')).toContainText('6')
+  await expect(page.getByTestId('parent-summary-recent')).toContainText(
+    'Build Groups and Equations'
+  )
+  await expect(page.getByText('Best stars: 3')).toBeVisible()
+  await expect(page.getByText('Badges: starter-builder')).toBeVisible()
+  await expect(page.getByText('Map rewards: grade-1-add-1')).toBeVisible()
+  await expect(page.getByText('Mode: latest-completion')).toBeVisible()
+})
+
+test('safe refresh keeps resumable progress and shows update prompts', async ({
+  page,
+}) => {
+  await createProfile(page, 'Ava')
+
+  await page.goto('/learn')
+  await page.getByRole('button', { name: 'Start lesson skeleton' }).click()
+  await page.getByRole('button', { name: 'Advance to next activity' }).click()
+  await expect(page.getByText('Current activity 2 of 3')).toBeVisible()
+
+  await page.addInitScript(() => {
+    window.__MATHINIK_TEST_SW_PROMPT__ = {
+      needRefresh: true,
+    }
+    window.__MATHINIK_TEST_CONTENT_STATUS__ = {
+      status: 'update-available',
+      cachedVersion: '2026.03.21',
+      latestVersion: '2026.04.01',
+    }
+  })
+
+  await page.goto('/')
+  await expect(
+    page.getByText('A fresh app version is available.')
+  ).toBeVisible()
+  await expect(page.getByRole('button', { name: 'Reload app' })).toBeVisible()
+  await page.getByRole('button', { name: 'Dismiss' }).click()
+  await expect(
+    page.locator('body').getByText('A fresh app version is available.')
+  ).toHaveCount(0)
+
+  await expect(
+    page.getByText('A newer content pack is available: 2026.04.01.')
+  ).toBeVisible()
+  await page.getByRole('button', { name: 'Apply safe refresh' }).click()
+  await expect(
+    page.getByText(
+      'Content refresh preserved local progress. Reload when ready to use the latest pack.'
+    )
+  ).toBeVisible()
+
+  await page.goto('/learn')
+  await expect(page.getByText('Current activity 2 of 3')).toBeVisible()
+  await expect(
+    page.getByText('Build the equation that matches the apple groups.')
+  ).toBeVisible()
+
+  await page.reload()
+
+  await expect(page.getByText('Current activity 2 of 3')).toBeVisible()
+})
+
 test('learner route restores resumable lesson progress after reload', async ({
   page,
 }) => {
@@ -83,5 +189,41 @@ async function createProfile(
   await expect(page.getByText(`Name: ${name}`)).toBeVisible()
   await expect(
     page.getByText('1 profile(s) stored on this device.')
+  ).toBeVisible()
+}
+
+async function completeFirstLesson(page: import('@playwright/test').Page) {
+  await page.goto('/learn')
+  await expect(page.getByText('Current activity 1 of 3')).toHaveCount(0)
+
+  const startButton = page.getByRole('button', {
+    name: 'Start lesson skeleton',
+  })
+  await expect(startButton).toBeEnabled()
+  await startButton.click()
+
+  await expect(page.getByText('Current activity 1 of 3')).toBeVisible()
+
+  await page.getByRole('button', { name: 'Record success' }).click()
+  await page.getByRole('button', { name: 'Advance to next activity' }).click()
+  await expect(page.getByText('Current activity 2 of 3')).toBeVisible()
+
+  await page.getByRole('button', { name: 'Record success' }).click()
+  await page
+    .getByRole('button', { name: 'Confirm second representation' })
+    .click()
+  await page.getByRole('button', { name: 'Advance to next activity' }).click()
+  await expect(page.getByText('Current activity 3 of 3')).toBeVisible()
+
+  await page.getByRole('button', { name: 'Record success' }).click()
+  await page.getByRole('button', { name: 'Finish lesson' }).click()
+
+  const wrapUpLink = page.getByRole('link', { name: 'See lesson wrap-up' })
+  await expect(wrapUpLink).toBeVisible()
+  await wrapUpLink.click()
+  await page.waitForURL('**/learn/completed')
+
+  await expect(
+    page.getByRole('heading', { name: 'Lesson complete' })
   ).toBeVisible()
 }


### PR DESCRIPTION
## Summary
- expand MIP-037 Playwright coverage across learner progression, completed-route navigation, parent summary verification, and safe refresh recovery
- add stable test hooks for update prompts and offline content status without changing normal runtime behavior
- append `progress.txt` and refresh `AGENT-HANDOFF.md` for the broader learner, parent, and offline E2E batch

## Validation
- pnpm lint
- pnpm test